### PR TITLE
Add AI opponent gameplay with difficulty levels

### DIFF
--- a/battleship-enhanced-features/battleship-enhanced-features/README.md
+++ b/battleship-enhanced-features/battleship-enhanced-features/README.md
@@ -29,11 +29,43 @@
 ```
 POST /games
 ```
-Response:
+
+**Request Body (optional)**
+
+```json
+{
+  "with_ai": true,
+  "difficulty": "hard",
+  "custom_ships": [...]
+}
+```
+
+- `with_ai`: `true` เพื่อเริ่มเกมสู้กับ AI (ค่าเริ่มต้น `false`).
+- `difficulty`: ระดับความยากของ AI (`"easy"`, `"medium"`, `"hard"`) ค่าเริ่มต้นคือ `"medium"`.
+- `custom_ships`: ระบุตำแหน่งเรือของผู้เล่นเอง (ใช้รูปแบบเดียวกับบริการ `validate`).
+
+**Response (เล่นคนเดียว)**
+
 ```json
 {
   "game_id": "uuid",
-  "board_state": [[...]]
+  "board_state": [[...]],
+  "has_ai": false
+}
+```
+
+**Response (เล่นกับ AI)**
+
+```json
+{
+  "game_id": "uuid",
+  "player_board_state": [[...]],
+  "ai_board_state": [[...]],
+  "player_ships_remaining": [...],
+  "ai_ships_remaining": [...],
+  "current_turn": "player",
+  "has_ai": true,
+  "ai_difficulty": "hard"
 }
 ```
 
@@ -41,17 +73,37 @@ Response:
 ```
 GET /games/{game_id}
 ```
-Response:
+
+**Response (เล่นคนเดียว)**
+
 ```json
 {
   "game_id": "uuid",
   "board_state": [[...]],
   "ships_remaining": [...],
-  "all_ships_sunk": false
+  "all_ships_sunk": false,
+  "has_ai": false
 }
 ```
 
-### 3. ยิงเป้า
+**Response (เล่นกับ AI)**
+
+```json
+{
+  "game_id": "uuid",
+  "player_board_state": [[...]],
+  "ai_board_state": [[...]],
+  "player_ships_remaining": [...],
+  "ai_ships_remaining": [...],
+  "all_ships_sunk": {"player": false, "ai": false},
+  "current_turn": "player",
+  "winner": null,
+  "has_ai": true,
+  "ai_difficulty": "medium"
+}
+```
+
+### 3. ยิงเป้า (เทิร์นของผู้เล่น)
 ```
 POST /games/{game_id}/fire
 Content-Type: application/json
@@ -60,7 +112,9 @@ Content-Type: application/json
   "position": "A1"
 }
 ```
-Response:
+
+**Response (เล่นคนเดียว)**
+
 ```json
 {
   "status": "hit|miss|already_shot|error",
@@ -69,6 +123,57 @@ Response:
   "board_state": [[...]],
   "ships_remaining": [...],
   "all_ships_sunk": false
+}
+```
+
+**Response (เล่นกับ AI)**
+
+```json
+{
+  "game_id": "uuid",
+  "has_ai": true,
+  "ai_difficulty": "medium",
+  "player_shot": {
+    "status": "hit|miss|already_shot|error",
+    "message": "...",
+    "position": "A1",
+    "target": "ai",
+    "ships_remaining": [...],
+    "all_ships_sunk": false
+  },
+  "player_board_state": [[...]],
+  "ai_board_state": [[...]],
+  "player_ships_remaining": [...],
+  "ai_ships_remaining": [...],
+  "current_turn": "ai"
+}
+```
+
+### 4. ให้ AI ยิง (เทิร์นของ AI)
+```
+POST /games/{game_id}/ai-shot
+```
+
+เรียกใช้หลังจากที่ `current_turn` เป็น `"ai"` ผลลัพธ์จะมีรายละเอียดการยิงของ AI:
+
+```json
+{
+  "game_id": "uuid",
+  "has_ai": true,
+  "ai_difficulty": "medium",
+  "ai_shot": {
+    "status": "hit|miss|already_shot|error",
+    "message": "...",
+    "position": "B5",
+    "target": "player",
+    "ships_remaining": [...],
+    "all_ships_sunk": false
+  },
+  "player_board_state": [[...]],
+  "ai_board_state": [[...]],
+  "player_ships_remaining": [...],
+  "ai_ships_remaining": [...],
+  "current_turn": "player"
 }
 ```
 
@@ -121,7 +226,7 @@ pytest
 ## ขั้นตอนถัดไป
 
 1. **Frontend Development**: สร้าง React frontend ด้วย Tailwind CSS
-2. **AI Integration**: เพิ่ม AI opponent
+2. **AI Improvements**: ปรับปรุงกลยุทธ์ AI เพิ่มเติม
 3. **Database**: เพิ่ม database สำหรับเก็บ game state
 4. **Authentication**: เพิ่มระบบ user authentication
 5. **Multiplayer**: เพิ่มฟีเจอร์ multiplayer

--- a/battleship-enhanced-features/battleship-enhanced-features/app/main.py
+++ b/battleship-enhanced-features/battleship-enhanced-features/app/main.py
@@ -22,6 +22,7 @@ class ShotRequest(BaseModel):
 class CreateGameRequest(BaseModel):
     with_ai: bool = False
     custom_ships: Optional[list] = None
+    difficulty: str = "medium"
 
 class ShipPlacement(BaseModel):
     ship_name: str
@@ -44,7 +45,11 @@ async def create_game(request: CreateGameRequest = CreateGameRequest()):
         # แปลง custom_ships เป็น format ที่ backend ต้องการ
         custom_ships = [ship.dict() if hasattr(ship, 'dict') else ship for ship in request.custom_ships]
     
-    game_data = GameService.create_new_game(with_ai=request.with_ai, custom_ships=custom_ships)
+    game_data = GameService.create_new_game(
+        with_ai=request.with_ai,
+        custom_ships=custom_ships,
+        difficulty=request.difficulty,
+    )
     
     if "error" in game_data:
         raise HTTPException(status_code=400, detail=game_data["error"])

--- a/battleship-enhanced-features/battleship-enhanced-features/app/models/board.py
+++ b/battleship-enhanced-features/battleship-enhanced-features/app/models/board.py
@@ -79,7 +79,7 @@ class Board:
             dict: A dictionary containing shot result (hit/miss) and updated board state.
         """
         if self.ships_board[row][col] == 'H' or self.ships_board[row][col] == 'M':
-            return {"status": "already_shot", "message": "You already shot at this position."}
+            return {"status": "already_shot", "message": "You already shot at this position.", "ship_sunk": False}
 
         for ship_name, position in list(self.ships_position.items()): # Use list() to allow modification during iteration
             if (row, col) in position:
@@ -87,10 +87,10 @@ class Board:
                 for r, c in position:
                     self.ships_board[r][c] = 'H'
                 del self.ships_position[ship_name] # Remove the ship if sunk
-                return {"status": "hit", "message": f"Hit! You sunk {ship_name}."}
+                return {"status": "hit", "message": f"Hit! You sunk {ship_name}.", "ship_sunk": True}
 
         self.ships_board[row][col] = 'M'
-        return {"status": "miss", "message": "Miss!"}
+        return {"status": "miss", "message": "Miss!", "ship_sunk": False}
 
     def all_ships_sunk(self) -> bool:
         """

--- a/battleship-enhanced-features/battleship-enhanced-features/app/services/game_service.py
+++ b/battleship-enhanced-features/battleship-enhanced-features/app/services/game_service.py
@@ -11,10 +11,56 @@ class GameService:
     _game_histories = {}  # เก็บประวัติเกม
 
     @classmethod
-    def create_new_game(cls, with_ai: bool = False, custom_ships: list = None) -> dict:
+    def create_new_game(
+        cls,
+        with_ai: bool = False,
+        custom_ships: list = None,
+        difficulty: str = "medium",
+    ) -> dict:
         game_id = str(uuid.uuid4())
+
+        if with_ai:
+            player_board = Board()
+            ai_board = Board()
+
+            if custom_ships:
+                result = player_board.place_ships_custom(custom_ships)
+                if not result["success"]:
+                    return {"error": result["message"]}
+            else:
+                player_board.place_ships_randomly()
+
+            ai_board.place_ships_randomly()
+
+            try:
+                ai_opponent = AIOpponent(difficulty)
+            except ValueError as exc:
+                return {"error": str(exc)}
+
+            cls._games[game_id] = {
+                "player_board": player_board,
+                "ai_board": ai_board,
+                "current_turn": "player",
+                "winner": None,
+                "difficulty": difficulty,
+            }
+            cls._ai_opponents[game_id] = ai_opponent
+
+            cls._game_histories[game_id] = GameHistory(game_id)
+
+            return {
+                "game_id": game_id,
+                "player_board_state": player_board.get_board_state(),
+                "ai_board_state": ai_board.get_board_state(),
+                "player_ships_remaining": player_board.get_ships_remaining(),
+                "ai_ships_remaining": ai_board.get_ships_remaining(),
+                "current_turn": "player",
+                "has_ai": True,
+                "ai_difficulty": difficulty,
+            }
+
         board = Board()
-        
+
         if custom_ships:
             # วางเรือตามที่กำหนด
             result = board.place_ships_custom(custom_ships)
@@ -23,135 +69,242 @@ class GameService:
         else:
             # วางเรือแบบสุ่ม
             board.place_ships_randomly()
-        
+
         cls._games[game_id] = board
-        
-        # สร้าง AI หากต้องการ
-        if with_ai:
-            cls._ai_opponents[game_id] = AIOpponent()
-        
+
         # สร้าง Game History
         cls._game_histories[game_id] = GameHistory(game_id)
-        
-        return {"game_id": game_id, "board_state": board.get_board_state(), "has_ai": with_ai}
+
+        return {"game_id": game_id, "board_state": board.get_board_state(), "has_ai": False}
 
     @classmethod
     def get_game_state_with_debug(cls, game_id: str) -> dict | None:
-        board = cls._games.get(game_id)
-        if board:
+        game_data = cls._games.get(game_id)
+        if not game_data:
+            return None
+
+        if cls._is_ai_game_data(game_data):
+            player_board = game_data["player_board"]
+            ai_board = game_data["ai_board"]
             return {
                 "game_id": game_id,
-                "board_state": board.get_board_state(),
-                "ships_remaining": board.get_ships_remaining(),
-                "all_ships_sunk": board.all_ships_sunk(),
-                "ships_position": board.ships_position
+                "player_board_state": player_board.get_board_state(),
+                "ai_board_state": ai_board.get_board_state(),
+                "player_ships_remaining": player_board.get_ships_remaining(),
+                "ai_ships_remaining": ai_board.get_ships_remaining(),
+                "player_ships_position": player_board.ships_position,
+                "ai_ships_position": ai_board.ships_position,
+                "all_ships_sunk": {
+                    "player": player_board.all_ships_sunk(),
+                    "ai": ai_board.all_ships_sunk(),
+                },
+                "has_ai": True,
+                "current_turn": game_data.get("current_turn"),
+                "winner": game_data.get("winner"),
+                "ai_difficulty": game_data.get("difficulty"),
             }
-        return None
+
+        board = game_data
+        return {
+            "game_id": game_id,
+            "board_state": board.get_board_state(),
+            "ships_remaining": board.get_ships_remaining(),
+            "all_ships_sunk": board.all_ships_sunk(),
+            "ships_position": board.ships_position
+        }
 
     @classmethod
     def get_game_state(cls, game_id: str) -> dict | None:
-        board = cls._games.get(game_id)
-        if board:
-            has_ai = game_id in cls._ai_opponents
+        game_data = cls._games.get(game_id)
+        if not game_data:
+            return None
+
+        if cls._is_ai_game_data(game_data):
+            player_board = game_data["player_board"]
+            ai_board = game_data["ai_board"]
             return {
                 "game_id": game_id,
-                "board_state": board.get_board_state(),
-                "ships_remaining": board.get_ships_remaining(),
-                "all_ships_sunk": board.all_ships_sunk(),
-                "has_ai": has_ai
+                "player_board_state": player_board.get_board_state(),
+                "ai_board_state": ai_board.get_board_state(),
+                "player_ships_remaining": player_board.get_ships_remaining(),
+                "ai_ships_remaining": ai_board.get_ships_remaining(),
+                "all_ships_sunk": {
+                    "player": player_board.all_ships_sunk(),
+                    "ai": ai_board.all_ships_sunk(),
+                },
+                "current_turn": game_data.get("current_turn"),
+                "winner": game_data.get("winner"),
+                "has_ai": True,
+                "ai_difficulty": game_data.get("difficulty"),
             }
-        return None
+
+        board = game_data
+        return {
+            "game_id": game_id,
+            "board_state": board.get_board_state(),
+            "ships_remaining": board.get_ships_remaining(),
+            "all_ships_sunk": board.all_ships_sunk(),
+            "has_ai": False
+        }
 
     @classmethod
     def take_shot(cls, game_id: str, position: str) -> dict | None:
-        board = cls._games.get(game_id)
-        if not board:
+        game_data = cls._games.get(game_id)
+        if not game_data:
             return None
 
-        # Assuming position is like 'A1', 'J10'
-        if len(position) < 2 or len(position) > 3:
-            return {"status": "error", "message": "Invalid position format. Expected A1-J10."}
+        try:
+            row, col = cls._parse_position(position)
+        except ValueError as exc:
+            return {"status": "error", "message": str(exc)}
 
-        # Parse position into row and column
-        # This part needs to handle 'A10' or 'J1' correctly
-        if position[0].isalpha() and position[1:].isdigit():
-            col_char = position[0]
-            row_num_str = position[1:]
-        elif position[0].isdigit() and position[1].isalpha(): # This case is less common for battleship but good to handle
-            row_num_str = position[0]
-            col_char = position[1]
-        else:
-            return {"status": "error", "message": "Invalid position format. Expected A1-J10."}
+        if cls._is_ai_game_data(game_data):
+            if game_data.get("winner"):
+                return {
+                    "status": "error",
+                    "message": "Game has already finished.",
+                    "current_turn": "finished",
+                    "winner": game_data.get("winner"),
+                    "game_id": game_id,
+                    "has_ai": True,
+                    "ai_difficulty": game_data.get("difficulty"),
+                }
 
-        if not GameUtils.is_valid_position(col_char, row_num_str):
-             return {"status": "error", "message": "Invalid position. Please enter a letter A-J and a number 1-10."}
+            if game_data.get("current_turn") != "player":
+                return {
+                    "status": "error",
+                    "message": "It's not the player's turn yet.",
+                    "current_turn": game_data.get("current_turn"),
+                    "game_id": game_id,
+                    "has_ai": True,
+                    "ai_difficulty": game_data.get("difficulty"),
+                }
 
-        row, col = GameUtils.parse_position(col_char, row_num_str)
+            player_board = game_data["player_board"]
+            ai_board = game_data["ai_board"]
+
+            shot_raw = ai_board.take_shot(row, col)
+            position_str = cls._format_position(row, col)
+            is_hit = shot_raw["status"] == "hit"
+            ship_sunk = shot_raw.get("ship_sunk", False)
+
+            if game_id in cls._game_histories:
+                history = cls._game_histories[game_id]
+                history.add_shot(position_str, shot_raw["status"], "player", is_hit, ship_sunk)
+                if ai_board.all_ships_sunk():
+                    history.end_game("player")
+
+            player_shot = {
+                "status": shot_raw["status"],
+                "message": shot_raw["message"],
+                "position": position_str,
+                "target": "ai",
+                "ship_sunk": ship_sunk,
+                "ships_remaining": ai_board.get_ships_remaining(),
+                "all_ships_sunk": ai_board.all_ships_sunk(),
+            }
+
+            if ai_board.all_ships_sunk():
+                game_data["current_turn"] = "finished"
+                game_data["winner"] = "player"
+            else:
+                game_data["current_turn"] = "ai"
+
+            response = {
+                "game_id": game_id,
+                "has_ai": True,
+                "ai_difficulty": game_data.get("difficulty"),
+                "player_shot": player_shot,
+                "player_board_state": player_board.get_board_state(),
+                "ai_board_state": ai_board.get_board_state(),
+                "player_ships_remaining": player_board.get_ships_remaining(),
+                "ai_ships_remaining": ai_board.get_ships_remaining(),
+                "current_turn": game_data.get("current_turn"),
+            }
+
+            if game_data.get("winner"):
+                response["winner"] = game_data.get("winner")
+
+            return response
+
+        board = game_data
 
         shot_result = board.take_shot(row, col)
         shot_result["game_id"] = game_id
         shot_result["board_state"] = board.get_board_state()
         shot_result["ships_remaining"] = board.get_ships_remaining()
         shot_result["all_ships_sunk"] = board.all_ships_sunk()
-        
-        # บันทึกประวัติ
+
         if game_id in cls._game_histories:
             history = cls._game_histories[game_id]
             is_hit = shot_result["status"] == "hit"
             ship_sunk = shot_result.get("ship_sunk", False)
             history.add_shot(position, shot_result["status"], "player", is_hit, ship_sunk)
-            
-            # ตรวจสอบว่าเกมจบหรือไม่
+
             if shot_result["all_ships_sunk"]:
                 history.end_game("player")
-        
-        # อัปเดต AI หากมี
-        if game_id in cls._ai_opponents:
-            ai = cls._ai_opponents[game_id]
-            is_hit = shot_result["status"] == "hit"
-            is_sunk = shot_result.get("ship_sunk", False)
-            ai.update_shot_result((row, col), is_hit, is_sunk)
-        
+
         return shot_result
 
     @classmethod
     def ai_take_shot(cls, game_id: str) -> dict | None:
         """ให้ AI ยิง"""
-        board = cls._games.get(game_id)
+        game_data = cls._games.get(game_id)
         ai = cls._ai_opponents.get(game_id)
-        
-        if not board or not ai:
+
+        if not game_data or not ai or not cls._is_ai_game_data(game_data):
             return None
-        
-        # ให้ AI เลือกตำแหน่งยิง
-        row, col = ai.get_next_shot()
-        
-        # ยิง
-        shot_result = board.take_shot(row, col)
-        shot_result["game_id"] = game_id
-        shot_result["board_state"] = board.get_board_state()
-        shot_result["ships_remaining"] = board.get_ships_remaining()
-        shot_result["all_ships_sunk"] = board.all_ships_sunk()
-        shot_result["ai_shot"] = True
-        shot_result["position"] = f"{chr(65 + col)}{row + 1}"  # แปลงกลับเป็น A1 format
-        
-        # อัปเดต AI
-        is_hit = shot_result["status"] == "hit"
-        is_sunk = shot_result.get("ship_sunk", False)
-        ai.update_shot_result((row, col), is_hit, is_sunk)
-        
-        # บันทึกประวัติ
-        if game_id in cls._game_histories:
-            history = cls._game_histories[game_id]
-            position_str = shot_result["position"]
-            ship_sunk = shot_result.get("ship_sunk", False)
-            history.add_shot(position_str, shot_result["status"], "ai", is_hit, ship_sunk)
-            
-            # ตรวจสอบว่าเกมจบหรือไม่ (AI ชนะ)
-            if shot_result["all_ships_sunk"]:
-                history.end_game("ai")
-        
-        return shot_result
+
+        if game_data.get("winner"):
+            return {
+                "status": "error",
+                "message": "Game has already finished.",
+                "current_turn": "finished",
+                "winner": game_data.get("winner"),
+                "game_id": game_id,
+                "has_ai": True,
+                "ai_difficulty": game_data.get("difficulty"),
+            }
+
+        if game_data.get("current_turn") != "ai":
+            return {
+                "status": "error",
+                "message": "It's not the AI's turn yet.",
+                "current_turn": game_data.get("current_turn"),
+                "game_id": game_id,
+                "has_ai": True,
+                "ai_difficulty": game_data.get("difficulty"),
+            }
+
+        shot_result = cls._execute_ai_turn(game_id)
+        if shot_result is None:
+            return None
+
+        player_board = game_data["player_board"]
+        ai_board = game_data["ai_board"]
+
+        if shot_result.get("all_ships_sunk"):
+            game_data["current_turn"] = "finished"
+            game_data["winner"] = "ai"
+        else:
+            game_data["current_turn"] = "player"
+
+        response = {
+            "game_id": game_id,
+            "has_ai": True,
+            "ai_difficulty": game_data.get("difficulty"),
+            "ai_shot": shot_result,
+            "player_board_state": player_board.get_board_state(),
+            "ai_board_state": ai_board.get_board_state(),
+            "player_ships_remaining": player_board.get_ships_remaining(),
+            "ai_ships_remaining": ai_board.get_ships_remaining(),
+            "current_turn": game_data.get("current_turn"),
+        }
+
+        if game_data.get("winner"):
+            response["winner"] = game_data.get("winner")
+
+        return response
 
     @classmethod
     def get_game_history(cls, game_id: str) -> dict | None:
@@ -181,5 +334,72 @@ class GameService:
         """ได้ข้อมูลเรือทั้งหมด"""
         temp_board = Board()
         return temp_board.ships
+
+    @classmethod
+    def _execute_ai_turn(cls, game_id: str) -> dict | None:
+        game_data = cls._games.get(game_id)
+        ai = cls._ai_opponents.get(game_id)
+
+        if not game_data or not ai or not cls._is_ai_game_data(game_data):
+            return None
+
+        player_board = game_data["player_board"]
+        row, col = ai.get_next_shot()
+        shot_raw = player_board.take_shot(row, col)
+        position_str = cls._format_position(row, col)
+        is_hit = shot_raw["status"] == "hit"
+        ship_sunk = shot_raw.get("ship_sunk", False)
+
+        ai.update_shot_result((row, col), is_hit, ship_sunk)
+
+        if game_id in cls._game_histories:
+            history = cls._game_histories[game_id]
+            history.add_shot(position_str, shot_raw["status"], "ai", is_hit, ship_sunk)
+            if player_board.all_ships_sunk():
+                history.end_game("ai")
+
+        return {
+            "game_id": game_id,
+            "status": shot_raw["status"],
+            "message": shot_raw["message"],
+            "position": position_str,
+            "target": "player",
+            "ai_shot": True,
+            "ship_sunk": ship_sunk,
+            "ships_remaining": player_board.get_ships_remaining(),
+            "all_ships_sunk": player_board.all_ships_sunk(),
+        }
+
+    @staticmethod
+    def _is_ai_game_data(game_data) -> bool:
+        return (
+            isinstance(game_data, dict)
+            and "player_board" in game_data
+            and "ai_board" in game_data
+        )
+
+    @staticmethod
+    def _parse_position(position: str) -> tuple[int, int]:
+        if len(position) < 2 or len(position) > 3:
+            raise ValueError("Invalid position format. Expected A1-J10.")
+
+        if position[0].isalpha() and position[1:].isdigit():
+            col_char = position[0]
+            row_num_str = position[1:]
+        elif position[0].isdigit() and position[1].isalpha():
+            row_num_str = position[0]
+            col_char = position[1]
+        else:
+            raise ValueError("Invalid position format. Expected A1-J10.")
+
+        if not GameUtils.is_valid_position(col_char, row_num_str):
+            raise ValueError("Invalid position. Please enter a letter A-J and a number 1-10.")
+
+        row, col = GameUtils.parse_position(col_char, row_num_str)
+        return row, col
+
+    @staticmethod
+    def _format_position(row: int, col: int) -> str:
+        return f"{chr(ord('A') + col)}{row + 1}"
 
 


### PR DESCRIPTION
## Summary
- allow starting games against an AI with selectable difficulty, dual boards, and tracked turns
- expand the AI engine with difficulty-specific shot selection, including a strategic hard mode pattern
- expose sunk status in board shots and document the new AI gameplay flow in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d10fa4ed5083338e2d777d855ec2c7