### PR TITLE
Fix AI difficulty selector markup

### DIFF
--- a/battleship-frontend/src/components/AIDifficultySelector.jsx
+++ b/battleship-frontend/src/components/AIDifficultySelector.jsx
@@ -43,38 +43,40 @@ const AIDifficultySelector = ({
         <h4 className="text-md font-semibold mb-3 text-gray-700">
           Choose AI Difficulty:
         </h4>
-          
-          <div className="space-y-3">
-            {difficulties.map((difficulty) => (
-              <label key={difficulty.value} className="flex items-start space-x-3 cursor-pointer">
-                <input
-                  type="radio"
-                  name="aiDifficulty"
-                  value={difficulty.value}
-                  checked={aiDifficulty === difficulty.value}
-                  onChange={(e) => setAiDifficulty(e.target.value)}
-                  disabled={disabled}
-                  className="mt-1 w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2 disabled:opacity-50"
-                />
-                <div className="flex-1">
-                  <div className={`font-medium ${difficulty.color}`}>
-                    {difficulty.label}
-                  </div>
-                  <div className="text-sm text-gray-500">
-                    {difficulty.description}
-                  </div>
+
+        <div className="space-y-3">
+          {difficulties.map((difficulty) => (
+            <label key={difficulty.value} className="flex items-start space-x-3 cursor-pointer">
+              <input
+                type="radio"
+                name="aiDifficulty"
+                value={difficulty.value}
+                checked={aiDifficulty === difficulty.value}
+                onChange={(e) => setAiDifficulty(e.target.value)}
+                disabled={disabled}
+                className="mt-1 w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2 disabled:opacity-50"
+              />
+              <div className="flex-1">
+                <div className={`font-medium ${difficulty.color}`}>
+                  {difficulty.label}
                 </div>
-              </label>
+                <div className="text-sm text-gray-500">
+                  {difficulty.description}
+                </div>
+              </div>
+            </label>
+          ))}
         </div>
       </div>
 
       {/* Info Box - Always show */}
       <div className="mt-4 p-3 bg-blue-50 border border-blue-200 rounded-md">
-          <div className="flex items-start space-x-2">
-            <div className="text-blue-600 text-lg">ℹ️</div>
-            <div className="text-sm text-blue-800">
-              <strong>Two-Board Mode:</strong> You'll attack the AI's board while defending your own. 
-              Take turns shooting until all ships on one side are destroyed!
+        <div className="flex items-start space-x-2">
+          <div className="text-blue-600 text-lg">ℹ️</div>
+          <div className="text-sm text-blue-800">
+            <strong>Two-Board Mode:</strong> You'll attack the AI's board while defending your own.
+            Take turns shooting until all ships on one side are destroyed!
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- close the AI difficulty radio group markup and restore the disabled opacity class string
- properly nest the informational callout content so the component renders valid JSX

## Testing
- ⚠️ `pnpm install` *(fails: environment blocks downloading pnpm 10.4.1)*
- ⚠️ `pnpm run build` *(fails: environment blocks downloading pnpm 10.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68d13c123a408333a5b15b8012368067