### PR TITLE
Restore debug mode visibility and honor custom ship placements

### DIFF
--- a/app/services/game_service.py
+++ b/app/services/game_service.py
@@ -62,6 +62,8 @@ class GameService:
             'game_id': game_id,
             'player_board_state': player_board.get_board_state(),
             'ai_board_state': ai_board.get_board_state() if ai_board else None,
+            'player_ships_positions': player_board.ships_position,
+            'ai_ships_positions': ai_board.ships_position if ai_board else None,
             'has_ai': with_ai,
             'ai_difficulty': ai_difficulty if with_ai else None,
             'current_turn': 'player',

--- a/battleship-frontend/src/App.jsx
+++ b/battleship-frontend/src/App.jsx
@@ -42,7 +42,7 @@ function App() {
   const { playSound, soundEnabled, setSoundEnabled } = useSoundEffects();
 
   // Create new game
-  const createNewGame = async (useCustomShips = false) => {
+  const createNewGame = async (useCustomShips = false, shipsOverride = null) => {
     try {
       // สำหรับเกมกับ AI - บังคับให้ใช้ Custom Ship Placement
       if (aiEnabled && !useCustomShips && !customShips) {
@@ -54,10 +54,17 @@ function App() {
       setMessage('Creating new game...');
       playSound('newGame');
 
+      const shipsToUse = useCustomShips ? (shipsOverride || customShips) : null;
+
+      if (useCustomShips && !shipsToUse) {
+        setMessage('Please place your ships before starting the game with AI!');
+        return;
+      }
+
       const requestBody = {
         with_ai: aiEnabled,
         ai_difficulty: aiDifficulty,
-        custom_ships: useCustomShips ? customShips : null
+        custom_ships: shipsToUse
       };
 
       const response = await fetch(`${API_BASE}/games`, {
@@ -80,14 +87,13 @@ function App() {
       setGameStatus(data.game_status);
       setCurrentTurn(data.current_turn);
       setMessage(aiEnabled ? 'Game started! Your turn to attack!' : 'Game started! Find all the ships!');
-      
-      // Reset debug boards
-      setPlayerDebugBoard(null);
-      setAiDebugBoard(null);
-      
+
+      setPlayerDebugBoard(data.player_ships_positions || null);
+      setAiDebugBoard(debugMode ? (data.ai_ships_positions || null) : null);
+
       // ปิด Ship Placement modal หลังจากสร้างเกมสำเร็จ
       setShowShipPlacement(false);
-      
+
       // Fetch initial game state for ships remaining
       fetchGameState(data.game_id);
       
@@ -115,14 +121,10 @@ function App() {
       setAiShipsRemaining(data.ai_ships_remaining || []);
       setGameStatus(data.game_status);
       setCurrentTurn(data.current_turn);
-      
-      // ตั้งค่า debug boards ถ้ามีข้อมูล
-      if (data.player_ships_positions) {
-        setPlayerDebugBoard(data.player_ships_positions);
-      }
-      if (data.ai_ships_positions) {
-        setAiDebugBoard(data.ai_ships_positions);
-      }
+
+      // ตั้งค่า debug boards
+      setPlayerDebugBoard(data.player_ships_positions || null);
+      setAiDebugBoard(debugMode ? (data.ai_ships_positions || null) : null);
       
     } catch (error) {
       console.error('Error fetching game state:', error);
@@ -261,7 +263,7 @@ function App() {
   const handleShipsPlaced = (ships) => {
     setCustomShips(ships);
     setShowShipPlacement(false);
-    createNewGame(true);
+    createNewGame(true, ships);
   };
 
   // Toggle debug mode

--- a/battleship-frontend/src/components/AIDifficultySelector.jsx
+++ b/battleship-frontend/src/components/AIDifficultySelector.jsx
@@ -43,38 +43,40 @@ const AIDifficultySelector = ({
         <h4 className="text-md font-semibold mb-3 text-gray-700">
           Choose AI Difficulty:
         </h4>
-          
-          <div className="space-y-3">
-            {difficulties.map((difficulty) => (
-              <label key={difficulty.value} className="flex items-start space-x-3 cursor-pointer">
-                <input
-                  type="radio"
-                  name="aiDifficulty"
-                  value={difficulty.value}
-                  checked={aiDifficulty === difficulty.value}
-                  onChange={(e) => setAiDifficulty(e.target.value)}
-                  disabled={disabled}
-                  className="mt-1 w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2 disabled:opacity-50"
-                />
-                <div className="flex-1">
-                  <div className={`font-medium ${difficulty.color}`}>
-                    {difficulty.label}
-                  </div>
-                  <div className="text-sm text-gray-500">
-                    {difficulty.description}
-                  </div>
+
+        <div className="space-y-3">
+          {difficulties.map((difficulty) => (
+            <label key={difficulty.value} className="flex items-start space-x-3 cursor-pointer">
+              <input
+                type="radio"
+                name="aiDifficulty"
+                value={difficulty.value}
+                checked={aiDifficulty === difficulty.value}
+                onChange={(e) => setAiDifficulty(e.target.value)}
+                disabled={disabled}
+                className="mt-1 w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2 disabled:opacity-50"
+              />
+              <div className="flex-1">
+                <div className={`font-medium ${difficulty.color}`}>
+                  {difficulty.label}
                 </div>
-              </label>
+                <div className="text-sm text-gray-500">
+                  {difficulty.description}
+                </div>
+              </div>
+            </label>
+          ))}
         </div>
       </div>
 
       {/* Info Box - Always show */}
       <div className="mt-4 p-3 bg-blue-50 border border-blue-200 rounded-md">
-          <div className="flex items-start space-x-2">
-            <div className="text-blue-600 text-lg">ℹ️</div>
-            <div className="text-sm text-blue-800">
-              <strong>Two-Board Mode:</strong> You'll attack the AI's board while defending your own. 
-              Take turns shooting until all ships on one side are destroyed!
+        <div className="flex items-start space-x-2">
+          <div className="text-blue-600 text-lg">ℹ️</div>
+          <div className="text-sm text-blue-800">
+            <strong>Two-Board Mode:</strong> You'll attack the AI's board while defending your own.
+            Take turns shooting until all ships on one side are destroyed!
+          </div>
         </div>
       </div>
     </div>

--- a/battleship-frontend/src/components/DualGameBoard.jsx
+++ b/battleship-frontend/src/components/DualGameBoard.jsx
@@ -1,65 +1,96 @@
 import React from 'react';
 
-const DualGameBoard = ({ 
-  playerBoard, 
-  aiBoard, 
-  onPlayerShot, 
-  currentTurn, 
+const extractShipPositions = (debugBoard) => {
+  const positions = new Set();
+
+  if (!debugBoard) {
+    return positions;
+  }
+
+  if (Array.isArray(debugBoard)) {
+    debugBoard.forEach((row, rowIndex) => {
+      if (!row) return;
+      row.forEach((cell, colIndex) => {
+        if (cell) {
+          positions.add(`${rowIndex}-${colIndex}`);
+        }
+      });
+    });
+    return positions;
+  }
+
+  Object.values(debugBoard).forEach((shipCells) => {
+    if (!shipCells) return;
+
+    shipCells.forEach((cell) => {
+      if (Array.isArray(cell) && cell.length === 2) {
+        const [row, col] = cell;
+        positions.add(`${row}-${col}`);
+      } else if (cell && typeof cell === 'object') {
+        if (typeof cell.row === 'number' && typeof cell.col === 'number') {
+          positions.add(`${cell.row}-${cell.col}`);
+        }
+      }
+    });
+  });
+
+  return positions;
+};
+
+const DualGameBoard = ({
+  playerBoard,
+  aiBoard,
+  onPlayerShot,
+  currentTurn,
   gameStatus,
   debugMode = false,
   playerDebugBoard = null,
   aiDebugBoard = null
 }) => {
-  const renderBoard = (board, debugBoard, isPlayerBoard, onCellClick) => {
+  const renderBoard = (board, debugBoard, isPlayerBoard, onCellClick, showShips) => {
     if (!board) return null;
+
+    const shipPositions = extractShipPositions(debugBoard);
+    const shouldShowShips = showShips && shipPositions.size > 0;
 
     return (
       <div className="grid grid-cols-11 gap-1 text-sm">
-        {/* Header row */}
         <div></div>
-        {['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'].map(col => (
+        {['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'].map((col) => (
           <div key={col} className="w-8 h-8 flex items-center justify-center font-bold text-gray-700">
             {col}
           </div>
         ))}
-        
-        {/* Board rows */}
+
         {board.map((row, rowIndex) => (
           <React.Fragment key={rowIndex}>
-            {/* Row number */}
             <div className="w-8 h-8 flex items-center justify-center font-bold text-gray-700">
               {rowIndex + 1}
             </div>
-            
-            {/* Board cells */}
+
             {row.map((cell, colIndex) => {
               const isClickable = !isPlayerBoard && currentTurn === 'player' && gameStatus === 'active';
-              // สำหรับผู้เล่น - แสดงเรือเสมอ, สำหรับ AI - แสดงเฉพาะใน debug mode
-              const hasShip = (isPlayerBoard && playerDebugBoard && playerDebugBoard[rowIndex] && playerDebugBoard[rowIndex][colIndex]) ||
-                             (!isPlayerBoard && debugMode && aiDebugBoard && aiDebugBoard[rowIndex] && aiDebugBoard[rowIndex][colIndex]);
-              
-              let cellClass = "w-8 h-8 border border-gray-400 flex items-center justify-center cursor-pointer transition-colors ";
-              let cellContent = "";
-              
-              // Cell styling based on state
+              const cellKey = `${rowIndex}-${colIndex}`;
+              const hasShip = shouldShowShips && shipPositions.has(cellKey);
+
+              let cellClass = 'w-8 h-8 border border-gray-400 flex items-center justify-center transition-colors';
+              let cellContent = '';
+
               if (cell === 'H') {
-                cellClass += "bg-red-500 text-white font-bold";
-                cellContent = "💥";
+                cellClass += ' bg-red-500 text-white font-bold';
+                cellContent = '💥';
               } else if (cell === 'M') {
-                cellClass += "bg-blue-200 text-blue-800";
-                cellContent = "💧";
+                cellClass += ' bg-blue-200 text-blue-800';
+                cellContent = '💧';
               } else if (hasShip) {
-                cellClass += "bg-gray-300 text-gray-700";
-                cellContent = "🚢";
+                cellClass += ' bg-gray-300 text-gray-700';
+                cellContent = '🚢';
               } else {
-                cellClass += "bg-blue-50 hover:bg-blue-100";
+                cellClass += ' bg-blue-50 hover:bg-blue-100';
               }
-              
-              // Disable clicking if not clickable
-              if (!isClickable) {
-                cellClass += " cursor-not-allowed";
-              }
-              
+
+              cellClass += isClickable ? ' cursor-pointer' : ' cursor-not-allowed';
+
               return (
                 <div
                   key={`${rowIndex}-${colIndex}`}
@@ -79,20 +110,14 @@ const DualGameBoard = ({
 
   return (
     <div className="flex flex-col lg:flex-row gap-8 items-start justify-center">
-      {/* Player's Board */}
       <div className="flex flex-col items-center">
-        <h3 className="text-xl font-bold mb-4 text-blue-600">
-          Your Board
-        </h3>
+        <h3 className="text-xl font-bold mb-4 text-blue-600">Your Board</h3>
         <div className="bg-white p-4 rounded-lg shadow-lg">
-          {renderBoard(playerBoard, playerDebugBoard, true, null)}
+          {renderBoard(playerBoard, playerDebugBoard, true, null, true)}
         </div>
-        <div className="mt-2 text-sm text-gray-600">
-          Defend your ships!
-        </div>
+        <div className="mt-2 text-sm text-gray-600">Defend your ships!</div>
       </div>
 
-      {/* VS Indicator */}
       {aiBoard && (
         <div className="flex items-center justify-center lg:mt-16">
           <div className="bg-gradient-to-r from-blue-500 to-red-500 text-white px-4 py-2 rounded-full font-bold text-lg shadow-lg">
@@ -101,19 +126,14 @@ const DualGameBoard = ({
         </div>
       )}
 
-      {/* AI's Board */}
       {aiBoard && (
         <div className="flex flex-col items-center">
-          <h3 className="text-xl font-bold mb-4 text-red-600">
-            AI's Board
-          </h3>
+          <h3 className="text-xl font-bold mb-4 text-red-600">AI's Board</h3>
           <div className="bg-white p-4 rounded-lg shadow-lg">
-            {renderBoard(aiBoard, aiDebugBoard, false, onPlayerShot)}
+            {renderBoard(aiBoard, aiDebugBoard, false, onPlayerShot, debugMode)}
           </div>
           <div className="mt-2 text-sm text-gray-600">
-            {currentTurn === 'player' && gameStatus === 'active' 
-              ? "Click to attack!" 
-              : "Wait for your turn..."}
+            {currentTurn === 'player' && gameStatus === 'active' ? 'Click to attack!' : 'Wait for your turn...'}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- keep ship positions for display while tracking remaining segments separately on the board model
- return ship positions from the game creation endpoint and wire the frontend to store them for later refreshes
- update the dual board UI to correctly render player ships at all times and reveal AI ships only in debug mode
- ensure AI games started after custom placement use the player's chosen ship layout instead of rolling a new random board

## Testing
- ✅ `pytest`
- ⚠️ `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_68d13c123a408333a5b15b8012368067